### PR TITLE
Adding a persistent volume claim to nagios template

### DIFF
--- a/nagios.yml
+++ b/nagios.yml
@@ -32,6 +32,17 @@ objects:
         insecureEdgeTerminationPolicy: "Allow"
   -
     apiVersion: "v1"
+    kind: "PersistentVolumeClaim"
+    metadata:
+      name: "nagios-claim-1"
+    spec:
+      accessModes:
+      - "ReadWriteOnce"
+      resources:
+        requests:
+          storage: "1Gi"
+  -
+    apiVersion: "v1"
     kind: "DeploymentConfig"
     metadata:
       labels:
@@ -80,9 +91,13 @@ objects:
               value: "${NAGIOS_USER}"
             - name: "NAGIOS_PASSWORD"
               value: "${NAGIOS_PASSWORD}"
+            volumeMounts:
+              - mountPath: "/var/log/nagios"
+                name: "nagios-data-volume"
           volumes:
-            - emptyDir:
-              name: "nagios-poc-data"
+          - name: "nagios-data-volume"
+            persistentVolumeClaim:
+              claimName: "nagios-claim-1"
 parameters:
 -
   description: "Nagios hostname to expose a route as"


### PR DESCRIPTION
Motivation:
We need to be able to persist nagios logs in the MBaaS by using a
persistent storage.

Modifications:
Updated the template to add a PersistentVolumeClaim and updated the
DeploymentDescriptor to use it.

Result:
The nagios pod should be using a persistent volume for storage.

To verify this you can run the following commands:
1. Create the persistent volume:

``` shell
$ cat nagios-pv.yaml
apiVersion: "v1"
kind: "PersistentVolume"
metadata:
  name: "nagios-pv"
spec:
  capacity:
    storage: "1Gi"
  accessModes:
    - "ReadWriteOnce"
  hostPath:
    path: /tmp/nagios
$ oc create -f nagios-pv.yaml
```
1. Process the template:

``` shell
$ oc process -f /mnt/src/mbaas-monitoring/nagios.yml
-v NAGIOS_HOST=example.com | oc create -f -
```
1. Verify that the persistent volume claim is bound:

``` shell
$ oc get pvc
NAME             LABELS    STATUS    VOLUME      CAPACITY   ACCESSMODES
AGE
nagios-claim-1   <none>    Bound     nagios-pv   1Gi        RWO
14s
```

JIRA:
https://issues.jboss.org/browse/RHMAP-4660
