### PR TITLE
Add dirs to volume in start script

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/bash
 
+# Add nagios dirs
+mkdir -p /var/log/nagios/archives \
+      /var/log/nagios/rw \
+      /var/log/nagios/spool/checkresults
+
 # Add nagios user
 htpasswd -c -b -s /etc/nagios/passwd ${NAGIOS_USER} ${NAGIOS_PASSWORD}
 


### PR DESCRIPTION
Motivation:
Things weren't working because we created directories that
were expected to be present in the Dockerfile, but then mounting a
volume over them, so they were hidden.

Modification:
These directories are now created in the start.sh
script, and also in the Dockerfile, so that it shouldn't matter if a
volume is being used or not.

Result:
Things were broken and now they work.
