### PR TITLE
Fix path to sendEmail that nagios uses

### DIFF
--- a/commands.cfg.j2
+++ b/commands.cfg.j2
@@ -1,9 +1,9 @@
 define command{
         command_name notify-host-by-email
-        command_line /usr/bin/printf "%b" "***** Nagios *****\n\nNotification Type: $NOTIFICATIONTYPE$\nHost: $HOSTNAME$\nState: $HOSTSTATE$\nAddress: $HOSTADDRESS$\nInfo: $HOSTOUTPUT$\n\nDate/Time: $LONGDATETIME$\n" | /usr/local/bin/sendEmail -o tls={{ smtp_tls }} -f {{ smtp_from_address }} -s {{ smtp_server }} -xu {{ smtp_username }} -xp {{ smtp_password }} -u "** $NOTIFICATIONTYPE$ Host Alert: $HOSTNAME$ is $HOSTSTATE$ **" -t $CONTACTEMAIL$
+        command_line /usr/bin/printf "%b" "***** Nagios *****\n\nNotification Type: $NOTIFICATIONTYPE$\nHost: $HOSTNAME$\nState: $HOSTSTATE$\nAddress: $HOSTADDRESS$\nInfo: $HOSTOUTPUT$\n\nDate/Time: $LONGDATETIME$\n" | /usr/bin/sendEmail -o tls={{ smtp_tls }} -f {{ smtp_from_address }} -s {{ smtp_server }} -xu {{ smtp_username }} -xp {{ smtp_password }} -u "** $NOTIFICATIONTYPE$ Host Alert: $HOSTNAME$ is $HOSTSTATE$ **" -t $CONTACTEMAIL$
 }
 
 define command{
         command_name notify-service-by-email
-        command_line /usr/bin/printf "%b" "***** Nagios *****\n\nNotification Type: $NOTIFICATIONTYPE$\n\nService: $SERVICEDESC$\nHost: $HOSTALIAS$\nAddress: $HOSTADDRESS$\nState: $SERVICESTATE$\n\nDate/Time: $LONGDATETIME$\n\nAdditional Info:\n\n$SERVICEOUTPUT$" | /usr/local/bin/sendEmail -o tls={{ smtp_tls }} -f {{ smtp_from_address }} -s {{ smtp_server }} -xu {{ smtp_username }} -xp {{ smtp_password }} -u "** $NOTIFICATIONTYPE$ Service Alert: $HOSTALIAS$/$SERVICEDESC$ is $SERVICESTATE$ **" -t $CONTACTEMAIL$
+        command_line /usr/bin/printf "%b" "***** Nagios *****\n\nNotification Type: $NOTIFICATIONTYPE$\n\nService: $SERVICEDESC$\nHost: $HOSTALIAS$\nAddress: $HOSTADDRESS$\nState: $SERVICESTATE$\n\nDate/Time: $LONGDATETIME$\n\nAdditional Info:\n\n$SERVICEOUTPUT$" | /usr/bin/sendEmail -o tls={{ smtp_tls }} -f {{ smtp_from_address }} -s {{ smtp_server }} -xu {{ smtp_username }} -xp {{ smtp_password }} -u "** $NOTIFICATIONTYPE$ Service Alert: $HOSTALIAS$/$SERVICEDESC$ is $SERVICESTATE$ **" -t $CONTACTEMAIL$
 }


### PR DESCRIPTION
Motivation:
Since we started to consume sendEmail from an RPM rather than bundling
it, it's in /usr/bin instead of /usr/local/bin. Nagios was unable to
send mail because of the incorrect location.

Modification:
Fixed the path to the command in the nagios commands that use it.

Result:
Nagios notifications now send email messages as intended
