### PR TITLE
Adding Nagios image name/version parameters.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
 - docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USER" -p="$DOCKER_PASS"  "$DOCKER_REGISTRY"
 - export REPO=docker.io/rhmap/nagios
 - export VERSION=4.0.8
-- export BUILD=2
+- export BUILD=3
 - docker build -f Dockerfile -t "$REPO:$VERSION-$BUILD" .
 
 after_success:

--- a/nagios.yml
+++ b/nagios.yml
@@ -71,7 +71,7 @@ objects:
         spec:
           containers:
           - name: "nagios"
-            image: "docker.io/rhmap/nagios:4.0.8-2"
+            image: "${NAGIOS_IMAGE_NAME}:${NAGIOS_IMAGE_VERSION}"
             ports:
               - containerPort: 8080
             env:
@@ -142,3 +142,11 @@ parameters:
   description: "Host or Service name for the MBaaS"
   name: "MBAAS_ROUTER_DNS"
   value: "fh-mbaas-service"
+-
+  description: "The name of the Nagios Docker image"
+  name: "NAGIOS_IMAGE_NAME"
+  value: "docker.io/rhmap/nagios"
+-
+  description: "The version of the Nagios Docker image"
+  name: "NAGIOS_IMAGE_VERSION"
+  value: "4.0.8-2"


### PR DESCRIPTION
Motivation:
Currently the Nagios image name version as specified in the template and
are not configurable without manually editing the template. Adding
template parameters would allow for the name and version to be updated
when the template is used.

Modifications:
Added NAGIOS_IMAGE_NAME and NAGIOS_IMAGE_VERSION parameters.

Result:
The template can be processed and the NAGIOS_IMAGE_NAME and
NAGIOS_IMAGE_VERSION can be specified:

$ oc process -f nagios.yml -v NAGIOS_IMAGE_NAME=rhmap4/nagios -v
NAGIOS_IMAGE_VERSION=4.0.8-6 -v NAGIOS_HOST=www.example.com -v
SMTP_USERNAME=dummy -v SMTP_PASSWORD=dummy

JIRA:
https://issues.jboss.org/browse/RHMAP-5962
